### PR TITLE
Generate Comparable SHA-1 Hash in SHA Test

### DIFF
--- a/sha/Makefile
+++ b/sha/Makefile
@@ -2,6 +2,6 @@ OBJS  = sha.o main.o
 
 include ../Makefile.mk
 
-CFLAGS += -DLITTLE_ENDIAN
+CFLAGS += -DLITTLE_ENDIAN -DUSE_MODIFIED_SHA
 
 more_clean:

--- a/sha/Makefile
+++ b/sha/Makefile
@@ -2,4 +2,6 @@ OBJS  = sha.o main.o
 
 include ../Makefile.mk
 
+CFLAGS += -DLITTLE_ENDIAN
+
 more_clean:

--- a/sha/sha.c
+++ b/sha/sha.c
@@ -191,14 +191,16 @@ void sha_final(SHA_INFO *sha_info)
 void sha_stream(SHA_INFO *sha_info, char *fin)
 {
     int i = 0;
-    BYTE data[BLOCK_SIZE];
 
     sha_init(sha_info);
     
-    while((data[0] = fin[i]) != '\0')
-    {
-      sha_update(sha_info, data, 1);
-      ++i;
+    while(*fin != '\0') {
+	i = 0;
+	while(fin[i] != '\0' && i < BLOCK_SIZE) {
+	    ++i;
+	}
+	sha_update(sha_info, fin, i);
+	fin += i;
     }
     sha_final(sha_info);
 }


### PR DESCRIPTION
These changes update the SHA test to output a hash that can be checked against the output of `sha1sum` on the same file contents.